### PR TITLE
Assoc payments with stripe id's

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ActiveRecord::Base
     # TODO: validate that there are no decimals in the amount
     raise "There is no credit card saved for this account" unless self.stripe_id
     begin
-      Stripe::Charge.create(
+      charge = Stripe::Charge.create(
         amount: amount, # amount in cents, again
         currency: "usd",
         customer: self.stripe_id,
@@ -54,6 +54,7 @@ class User < ActiveRecord::Base
     rescue => e
       logger.info(e)
     end
+    charge
   end
 
   def credit_card

--- a/db/migrate/20131224032312_add_stripe_id_to_payments.rb
+++ b/db/migrate/20131224032312_add_stripe_id_to_payments.rb
@@ -1,0 +1,5 @@
+class AddStripeIdToPayments < ActiveRecord::Migration
+  def change
+    add_column :payments, :stripe_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131130093027) do
+ActiveRecord::Schema.define(version: 20131224032312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 20131130093027) do
     t.datetime "updated_at"
     t.integer  "last4"
     t.integer  "user_id"
+    t.string   "stripe_id"
   end
 
   create_table "retreat_registrations", force: true do |t|


### PR DESCRIPTION
Simple fix. Uses the ID straight from the charge object we get in the user#charge method; if there's an exception, we follow the same error path we had before. 
