### PR TITLE
Strong params for devise & ParameterSanitizer error fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,12 +3,12 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   layout 'application'
+  before_filter :configure_permitted_parameters, if: :devise_controller?
 
-  def devise_parameter_sanitizer
-    if resource_class == User
-      User::ParameterSanitizer.new(User, :user, params)
-    else
-      super
-    end
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:account_update) { |u| u.permit(:fname, :lname, :email, :password, :password_confirmation, :current_password, :line1, :city, :state, :zip, :phone, :gender, :birthday, :shirtsize) }
+    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:fname, :lname, :email, :password, :password_confirmation) }
   end
 end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,2 +1,0 @@
-class ConfirmationsController < Devise::ConfirmationsController
-end

--- a/config/initializers/sanitizers.rb
+++ b/config/initializers/sanitizers.rb
@@ -1,1 +1,0 @@
-require "#{Rails.application.root}/lib/user_sanitizer.rb"

--- a/lib/user_sanitizer.rb
+++ b/lib/user_sanitizer.rb
@@ -1,9 +1,0 @@
-class User::ParameterSanitizer < Devise::ParameterSanitizer
-	private
-    def account_update
-      default_params.permit(:fname, :lname, :email, :password, :password_confirmation, :current_password, :line1, :city, :state, :zip, :phone, :gender, :birthday, :shirtsize)
-    end
-    def sign_up
-      default_params.permit(:fname, :lname, :email, :password, :password_confirmation)
-    end
-end


### PR DESCRIPTION
Removed old way of sanitizing non-default user parameters which caused User::ParameterSanitizer errors. Took out unused confirmations controller.

Addresses #87.

Routes affected: /login, /register, /account/profile
