### PR TITLE
Fixed unicorn deploy script

### DIFF
--- a/config/rubber/deploy-unicorn.rb
+++ b/config/rubber/deploy-unicorn.rb
@@ -2,33 +2,38 @@
 namespace :rubber do
 
   namespace :unicorn do
-  
+
     rubber.allow_optional_tasks(self)
-    
+
     before "deploy:stop", "rubber:unicorn:stop"
     after "deploy:start", "rubber:unicorn:start"
     after "deploy:restart", "rubber:unicorn:reload"
-    
+
     desc "Stops the unicorn server"
     task :stop, :roles => :unicorn do
-      rsudo "if [ -f /var/run/unicorn.pid ]; then pid=`cat /var/run/unicorn.pid` && kill -TERM $pid; fi"
+      rsudo "service unicorn stop"
     end
-    
+
+    desc "Forcefully kills the unicorn server"
+    task :force_stop, :roles => :unicorn do
+      rsudo "service unicorn force-stop"
+    end
+
     desc "Starts the unicorn server"
     task :start, :roles => :unicorn do
-      rsudo "cd #{current_path} && bundle exec unicorn_rails -c #{current_path}/config/unicorn.rb -E #{Rubber.env} -D"
+      rsudo "service unicorn start"
     end
-    
+
     desc "Restarts the unicorn server"
     task :restart, :roles => :unicorn do
-      stop
-      start
+      rsudo "service unicorn restart"
     end
-  
+
     desc "Reloads the unicorn web server"
     task :reload, :roles => :unicorn do
-      rsudo "if [ -f /var/run/unicorn.pid ]; then pid=`cat /var/run/unicorn.pid` && kill -USR2 $pid; else cd #{current_path} && bundle exec unicorn_rails -c #{current_path}/config/unicorn.rb -E #{Rubber.env} -D; fi"
+      rsudo "service unicorn upgrade"
     end
+
 
     desc "Display status of the unicorn web server"
     task :status, :roles => :unicorn do

--- a/config/rubber/role/unicorn/unicorn.rb
+++ b/config/rubber/role/unicorn/unicorn.rb
@@ -49,7 +49,7 @@ before_fork do |server, worker|
       # someone else did our job for us
     end
   end
-  
+
   # This option works in together with preload_app true setting
   # What is does is prevent the master process from holding
   # the database connection
@@ -79,7 +79,7 @@ after_fork do |server, worker|
       raise e
     end
   end
-  
+
   # Here we are establishing the connection after forking worker
   # processes
   defined?(ActiveRecord::Base) and


### PR DESCRIPTION
Unicorn should now properly kill old unicorn master and worker processes and start new ones.

Routes affected: none
