### PR TITLE
Renamed application from Static to TMCYF

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@
 
 require File.expand_path('../config/application', __FILE__)
 
-Static::Application.load_tasks
+TMCYF::Application.load_tasks

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ require "csv"
 # you've limited to :test, :development, or :production.
 Bundler.require(:default, Rails.env)
 
-module Static
+module TMCYF
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,4 +2,4 @@
 require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
-Static::Application.initialize!
+TMCYF::Application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-Static::Application.configure do
+TMCYF::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-Static::Application.configure do
+TMCYF::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-Static::Application.configure do
+TMCYF::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,4 +9,4 @@
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-Static::Application.config.secret_key_base = ENV['SECRET_KEY_BASE']
+TMCYF::Application.config.secret_key_base = ENV['SECRET_KEY_BASE']

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Static::Application.config.session_store :cookie_store, key: '_static_session'
+TMCYF::Application.config.session_store :cookie_store, key: '_static_session'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Static::Application.routes.draw do
+TMCYF::Application.routes.draw do
 
   mount RailsAdmin::Engine => '/admin2', :as => 'rails_admin'
   resources :give, only: [:index, :new, :create]


### PR DESCRIPTION
Noticed that the application was named Static from the green days. Renamed application appropriately.

Routes affected: all?
