### PR TITLE
Replaces phone number from incoming SMS to name

### DIFF
--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -21,14 +21,17 @@ class SmsController < ApplicationController
   end
 
   def receive_sms
+    # Pulls in params from Twilio request
+    # Converts the number to a name, if the name exists in the database.
+    # Creates a payload to send to Slack as JSON
     msg_body = params["Body"]
     from_num = params["From"]
-
+    from_name = SMS.convert(from_num)
     payload = {
-      text: "From: #{from_num}. Message: #{msg_body}"
+      text: "From: #{from_name}. Message: #{msg_body}"
     }.to_json
 
-    uri = URI('https://tmcyf.slack.com/services/hooks/incoming-webhook?token=lFAo4KrEmegGC3IoBnbfYvdP')
+    uri = URI('https://hooks.slack.com/services/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')
     @res = Net::HTTP.post_form(uri, 'payload' => payload)
 
     render json: @res

--- a/app/models/sms.rb
+++ b/app/models/sms.rb
@@ -2,11 +2,26 @@ class SMS
   attr_accessor :message
 
   def initialize(message)
-    begin 
+    begin
       message.encode(Encoding::ISO_8859_1)
       @message = message
     rescue Encoding::UndefinedConversionError
       raise InvalidEncodingError, "You input a chacter that SMSes can't read."
+    end
+  end
+
+  def self.convert(from_num)
+
+    # This method can probably be refactored but I don't know enough to attempt it. I'm just glad it works.
+    # It pulls in variable from controller, strips out country code, checks if user with number exists in DB
+    # and spits out a full name. The fullname method is borrowed from the User model. If user doesn't exist
+    # it returns the stripped number.
+
+    from_num = from_num.gsub(/^\+\d/, "")
+    if User.exists?(:phone => from_num)
+      from_name = User.find_by_phone("#{from_num}").fullname
+    else
+      from_name = from_num
     end
   end
 


### PR DESCRIPTION
Every SMS that the committee gets goes to the #texts channel on Slack. The webhook would print the number that Twilio sent and anyone in the channel would have to look it up to see who it is from. This commit replaces the number with a name, provided that number exists in the database.


Decided to procrastinate and add this feature. The code can probably be refactored but I'm glad a couple hours paid off.